### PR TITLE
Handle na values

### DIFF
--- a/house-prices.py
+++ b/house-prices.py
@@ -46,9 +46,16 @@ x_train, x_val, y_train, y_val = train_test_split(
 numeric_features = data_df.select_dtypes(include="number").columns
 numeric_features = numeric_features.drop("SalePrice")
 
-## Analyze NA values
-na_feature_counts = data_df[numeric_features].isna().sum()
-na_feature_counts = na_feature_counts[na_feature_counts > 0]
+
+# Analyze NA values
+def list_na_features(df):
+    na_feature_counts = df[numeric_features].isna().sum()
+    return na_feature_counts[na_feature_counts > 0]
+
+
+## Check there isn't a large discrepency in na values between training and test sets (there isn't)
+list_na_features(data_df)
+list_na_features(test_df)
 
 ## Drop features with too many NA values
 features_to_drop = ["LotFrontage", "GarageYrBlt"]  # Based on initial analysis

--- a/house-prices.py
+++ b/house-prices.py
@@ -80,13 +80,20 @@ na_fill_values = {
     "LotFrontage": x_train.LotFrontage.median(),
 }
 
-## na_feature descriptions:
-## GarageYrBlt: Year garage was built
-## MasVnrArea: Masonry veneer area in square feet
+### MasVnrArea: Masonry veneer area in square feet
+#### Most values are zero
+data_df.MasVnrArea.describe()
 
+#### The MasVnrType can likely tell us if an na value is simply not recorded or if it's 0
+data_df.MasVnrType.value_counts(dropna=False)
+#### Let's sanity check that a Veneer area of 0 has a na MasVnrType (it does)
+data_df.MasVnrType[data_df.MasVnrArea == 0].value_counts(dropna=False)
+#### Let's check if the MasVnrType is na when the MasVnrArea is na (it is)
+data_df.MasVnrType[data_df.MasVnrArea.isna()].value_counts(dropna=False)
 
-## Drop features with too many NA values
-numeric_features = numeric_features.drop("GarageYrBlt")
+#### Unlike LotFrontage, MasVnrArea is likely to be 0 when the value is missing
+#### Meaning we should fill the na values with 0
+na_fill_values["MasVnrArea"] = 0
 
 
 # Scale the features, only fit the scaler on training data

--- a/house-prices.py
+++ b/house-prices.py
@@ -110,7 +110,7 @@ def preprocess_data(
 ):
     df = df[feature_column_names]
     df = df.fillna(na_fill_values)
-    df = df.fillna(0)
+    df = df.fillna(x_train.mode().iloc[0])
     df = scale_data(df, scaler, is_training)
     return df
 

--- a/house-prices.py
+++ b/house-prices.py
@@ -72,8 +72,13 @@ not_na_lot_frontage_df.SalePrice.median()
 
 #### Apartments will often have 0 lot frontage, let's check if any exist within our dataset
 data_df.BldgType.unique()
-#### None of these are apartments, I think it's safe to assume these values are missing and not 0
 
+
+#### None of these are apartments, I think it's safe to assume these values are missing and not 0
+#### Meaning we should fill the na values with a median or mean value rather than 0.
+na_fill_values = {
+    "LotFrontage": x_train.LotFrontage.median(),
+}
 
 ## na_feature descriptions:
 ## GarageYrBlt: Year garage was built
@@ -81,8 +86,7 @@ data_df.BldgType.unique()
 
 
 ## Drop features with too many NA values
-features_to_drop = ["LotFrontage", "GarageYrBlt"]  # Based on initial analysis
-numeric_features = numeric_features.drop(features_to_drop)
+numeric_features = numeric_features.drop("GarageYrBlt")
 
 
 # Scale the features, only fit the scaler on training data
@@ -98,6 +102,7 @@ def preprocess_data(
     df, feature_column_names, scaler: StandardScaler, is_training: bool
 ):
     df = df[feature_column_names]
+    df = df.fillna(na_fill_values)
     df = df.fillna(0)
     df = scale_data(df, scaler, is_training)
     return df

--- a/house-prices.py
+++ b/house-prices.py
@@ -57,6 +57,16 @@ def list_na_features(df):
 list_na_features(data_df)
 list_na_features(test_df)
 
+## Take a look at features with significant na values
+na_feature_names = list_na_features(data_df).index.to_list()
+na_feature_df = data_df[na_feature_names]
+na_feature_df.head()
+## na_feature descriptions:
+## LotFrontage: Linear feet of street connected to property
+## GarageYrBlt: Year garage was built
+## MasVnrArea: Masonry veneer area in square feet
+
+
 ## Drop features with too many NA values
 features_to_drop = ["LotFrontage", "GarageYrBlt"]  # Based on initial analysis
 numeric_features = numeric_features.drop(features_to_drop)

--- a/house-prices.py
+++ b/house-prices.py
@@ -58,11 +58,24 @@ list_na_features(data_df)
 list_na_features(test_df)
 
 ## Take a look at features with significant na values
-na_feature_names = list_na_features(data_df).index.to_list()
-na_feature_df = data_df[na_feature_names]
-na_feature_df.head()
+### LotFrontage: Linear feet of street connected to property
+### This is a measure of the street connected to the property
+### It's possible that 0 values mean there is no street connected to the property or it could just be a missing value
+#### Having 0 lot frontage would likely be a negative factor in the sale price
+#### Let's compare the median sale price of properties with 0 lot frontage to the median sale price of properties with non-0 lot frontage
+
+not_na_lot_frontage_df = data_df[~data_df.LotFrontage.isna()]
+data_df.SalePrice.median()
+not_na_lot_frontage_df.SalePrice.median()
+
+#### The median sale prices aren't that different, meaning the na values are missing recordings rather than 0
+
+#### Apartments will often have 0 lot frontage, let's check if any exist within our dataset
+data_df.BldgType.unique()
+#### None of these are apartments, I think it's safe to assume these values are missing and not 0
+
+
 ## na_feature descriptions:
-## LotFrontage: Linear feet of street connected to property
 ## GarageYrBlt: Year garage was built
 ## MasVnrArea: Masonry veneer area in square feet
 


### PR DESCRIPTION
Re-add features with significant na values
Analyse why they have na values
Replace na values with median, mode or 0 values after analysing why they're missing.
Swap default na filling from 0 to mode.

## Results
This didn't have a big impact on our metrics. In future I will depriotize investigating na values within large feature sets.

```
Training RMSE: 33847.46
Validation RMSE: 36755.86
Training R²: 0.81
Validation R²: 0.82
```
<img width="692" alt="image" src="https://github.com/user-attachments/assets/4c9ab8e1-f336-4020-ae30-b824e38c8e48" />


